### PR TITLE
Add Luna assistant prototype with modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ the project directory.
 Run the assistant:
 
 ```bash
-python -m assistant.main --debug
+python -m assistant.main --debug --voice en-us-kathleen-low
 ```
 
-Say **"Hey Luna"** followed by a supported command (see `assistant/commands.yml`).
+Say **"Hey Luna"** followed by a polite request. Luna introspects its tools
+from `capabilities.json` and chooses the right action.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # Kyra-AI-Assistant
 
-This project contains a simple offline voice assistant that responds to the wake word **"Hey Nova"** and can execute a few basic spoken commands.
+This project contains a simple offline voice assistant and a more modular
+prototype. The original script `nova_assistant.py` listens for **"Hey Nova"**
+and executes a few basic commands. The new `assistant/` package provides a
+more extensible assistant called **Luna** using a wake phrase "Hey Luna".
 
 ## Requirements
 
-- Python 3.8+
+- Python 3.10+
 - [Vosk](https://alphacephei.com/vosk/) offline speech recognition model
-- `pyttsx3`, `pyaudio`, `vosk`, `keyboard`
+- Additional Python packages listed in `assistant/requirements.txt`
 
 Install dependencies with:
 
 ```bash
-pip install vosk pyttsx3 pyaudio keyboard
+pip install -r assistant/requirements.txt
 ```
 
-Download the Vosk model (e.g., `vosk-model-small-en-us-0.15`) and extract it into the project directory.
+Download the Vosk model (e.g. `vosk-model-small-en-us-0.15`) and extract it into
+the project directory.
 
 ## Usage
 
 Run the assistant:
 
 ```bash
-python nova_assistant.py
+python -m assistant.main --debug
 ```
 
-Say **"Hey Nova"** followed by a command such as "open YouTube".
+Say **"Hey Luna"** followed by a supported command (see `assistant/commands.yml`).

--- a/assistant/__init__.py
+++ b/assistant/__init__.py
@@ -1,0 +1,1 @@
+from . import actions  # noqa: F401

--- a/assistant/actions.py
+++ b/assistant/actions.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import webbrowser
+from typing import Dict, Tuple
+
+
+def open_website(url: str) -> Tuple[bool, str]:
+    """Open a website in the default browser."""
+    try:
+        if not url.startswith("http"):
+            url = "https://" + url
+        webbrowser.open_new_tab(url)
+        return True, f"Opening {url}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def launch(app_path: str) -> Tuple[bool, str]:
+    """Launch an application given its path."""
+    try:
+        os.startfile(app_path)  # type: ignore[attr-defined]
+        return True, f"Launching {app_path}"
+    except Exception as exc:
+        try:
+            subprocess.Popen(app_path)
+            return True, f"Launching {app_path}"
+        except Exception:
+            return False, str(exc)
+
+
+def search_files(pattern: str, root: str) -> Tuple[bool, str]:
+    """Search for files matching pattern under root."""
+    matches = []
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            if pattern.lower() in f.lower():
+                matches.append(os.path.join(dirpath, f))
+    if matches:
+        return True, "Found: " + "; ".join(matches[:5])
+    return False, "No files found"
+
+
+def reveal_folder(path: str) -> Tuple[bool, str]:
+    """Open folder in Explorer."""
+    try:
+        os.startfile(path)  # type: ignore[attr-defined]
+        return True, f"Opening folder {path}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+# Dispatcher mapping
+actions: Dict[str, callable] = {
+    "open_website": open_website,
+    "launch": launch,
+    "search_files": search_files,
+    "reveal_folder": reveal_folder,
+}
+
+
+def dispatch(action_name: str, **kwargs) -> Tuple[bool, str]:
+    if action_name not in actions:
+        return False, f"Unknown action {action_name}"
+    return actions[action_name](**kwargs)

--- a/assistant/actions.py
+++ b/assistant/actions.py
@@ -3,7 +3,10 @@ import subprocess
 import webbrowser
 from typing import Dict, Tuple
 
+from .tools import tool, export_capabilities
 
+
+@tool
 def open_website(url: str) -> Tuple[bool, str]:
     """Open a website in the default browser."""
     try:
@@ -15,20 +18,22 @@ def open_website(url: str) -> Tuple[bool, str]:
         return False, str(exc)
 
 
-def launch(app_path: str) -> Tuple[bool, str]:
+@tool
+def launch_app(path: str) -> Tuple[bool, str]:
     """Launch an application given its path."""
     try:
-        os.startfile(app_path)  # type: ignore[attr-defined]
-        return True, f"Launching {app_path}"
+        os.startfile(path)  # type: ignore[attr-defined]
+        return True, f"Launching {path}"
     except Exception as exc:
         try:
-            subprocess.Popen(app_path)
-            return True, f"Launching {app_path}"
+            subprocess.Popen(path)
+            return True, f"Launching {path}"
         except Exception:
             return False, str(exc)
 
 
-def search_files(pattern: str, root: str) -> Tuple[bool, str]:
+@tool
+def search_files(pattern: str, root: str = "~") -> Tuple[bool, str]:
     """Search for files matching pattern under root."""
     matches = []
     for dirpath, _dirs, files in os.walk(root):
@@ -40,6 +45,7 @@ def search_files(pattern: str, root: str) -> Tuple[bool, str]:
     return False, "No files found"
 
 
+@tool
 def reveal_folder(path: str) -> Tuple[bool, str]:
     """Open folder in Explorer."""
     try:
@@ -48,17 +54,5 @@ def reveal_folder(path: str) -> Tuple[bool, str]:
     except Exception as exc:
         return False, str(exc)
 
-
-# Dispatcher mapping
-actions: Dict[str, callable] = {
-    "open_website": open_website,
-    "launch": launch,
-    "search_files": search_files,
-    "reveal_folder": reveal_folder,
-}
-
-
-def dispatch(action_name: str, **kwargs) -> Tuple[bool, str]:
-    if action_name not in actions:
-        return False, f"Unknown action {action_name}"
-    return actions[action_name](**kwargs)
+# Export tool registry to capabilities.json when this module is imported
+export_capabilities()

--- a/assistant/commands.yml
+++ b/assistant/commands.yml
@@ -1,0 +1,42 @@
+- id: open_website
+  phrases:
+    - "open {site} in my browser"
+    - "go to {site}"
+    - "open {site}"
+    - "launch website {site}"
+  slots:
+    site: "(?:https?://)?[\\w\\.-]+\\.[a-z]{2,}"
+  action: open_website
+  args:
+    url: "{site}"
+
+- id: launch_app
+  phrases:
+    - "start {app}"
+    - "open {app} application"
+  slots:
+    app: "(notepad|calculator|discord)"
+  action: launch
+  args:
+    app_path_map:
+      notepad: "C:\\Windows\\system32\\notepad.exe"
+      calculator: "calc.exe"
+      discord: "%LOCALAPPDATA%\\Discord\\Update.exe"
+
+- id: search_file
+  phrases:
+    - "find file named {name}"
+    - "locate {name} file"
+  slots:
+    name: "[\\w\\s\\.]+"
+  action: search_files
+  args:
+    root: "C:\\Users"
+
+- id: open_downloads
+  phrases:
+    - "show my downloads folder"
+    - "open downloads"
+  action: reveal_folder
+  args:
+    path: "%USERPROFILE%\\Downloads"

--- a/assistant/filler_words.txt
+++ b/assistant/filler_words.txt
@@ -1,0 +1,6 @@
+please
+could you
+would you kindly
+can you
+please,
+kindly

--- a/assistant/main.py
+++ b/assistant/main.py
@@ -1,0 +1,86 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+from typing import Dict
+
+from vosk import KaldiRecognizer, Model
+
+from .stt import speech_chunks
+from .nlu import load_commands, NLU
+from .actions import dispatch
+from .tts import speak
+
+logging.basicConfig(
+    filename="assistant.log",
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(message)s",
+)
+
+WAKE_WORD = "hey luna"
+MODEL_PATH = "vosk-model-small-en-us-0.15"
+
+
+async def load_stt() -> KaldiRecognizer:
+    if not os.path.exists(MODEL_PATH):
+        raise FileNotFoundError(
+            f"Vosk model not found at {MODEL_PATH}. Download from https://alphacephei.com/vosk/models"
+        )
+    model = Model(MODEL_PATH)
+    return KaldiRecognizer(model, 16000)
+
+
+async def handle_command(text: str, nlu: NLU, tts_enabled: bool) -> None:
+    intent, slots, _conf = nlu.predict(text)
+    if not intent:
+        speak("Sorry, I didn't understand.", tts_enabled)
+        return
+    cmd = next(c for c in nlu.commands if c.id == intent)
+    args: Dict[str, str] = {}
+    for k, v in cmd.args.items():
+        if isinstance(v, dict):
+            slot_val = slots.get(k)
+            if slot_val:
+                mapped = v.get(slot_val)
+                if mapped:
+                    args[k] = os.path.expandvars(mapped)
+        else:
+            args[k] = os.path.expandvars(v.format(**slots))
+    ok, msg = dispatch(cmd.action, **args)
+    speak(msg, tts_enabled)
+    if not ok:
+        logging.error("Action failed: %s", msg)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--mic_index", type=int, default=None)
+    parser.add_argument("--headless", action="store_true")
+    args = parser.parse_args()
+
+    commands = load_commands(os.path.join(os.path.dirname(__file__), "commands.yml"))
+    nlu = NLU(commands)
+    recognizer = await load_stt()
+
+    gen = speech_chunks(args.mic_index)
+    state = "wake"
+    command_text = ""
+    async for chunk in gen:
+        if recognizer.AcceptWaveform(chunk):
+            res = json.loads(recognizer.Result())
+            text = res.get("text", "").lower()
+            if args.debug and text:
+                print("STT:", text)
+            if state == "wake" and text.startswith(WAKE_WORD):
+                speak("I'm listening", not args.headless)
+                state = "command"
+            elif state == "command" and text:
+                command_text = text
+                await handle_command(command_text, nlu, not args.headless)
+                state = "wake"
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/assistant/nlu.py
+++ b/assistant/nlu.py
@@ -1,0 +1,81 @@
+import os
+import re
+import yaml
+import joblib
+from typing import Any, Dict, List, Tuple
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from rapidfuzz import fuzz
+
+
+class Command:
+    def __init__(self, data: Dict[str, Any]):
+        self.id = data['id']
+        self.phrases = data.get('phrases', [])
+        self.slots = {name: re.compile(pattern, re.I) for name, pattern in data.get('slots', {}).items()}
+        self.action = data['action']
+        self.args = data.get('args', {})
+
+
+class NLU:
+    def __init__(self, commands: List[Command], model_path: str = 'nlu.joblib'):
+        self.commands = commands
+        self.model_path = model_path
+        texts = []
+        labels = []
+        for cmd in commands:
+            for p in cmd.phrases:
+                # replace slot markers with the slot name so the model can generalise
+                processed = re.sub(r"{(\w+)}", r"\1", p)
+                texts.append(processed)
+                labels.append(cmd.id)
+        if os.path.exists(model_path):
+            self.vectorizer, self.clf = joblib.load(model_path)
+        else:
+            self.vectorizer = TfidfVectorizer()
+            X = self.vectorizer.fit_transform(texts)
+            self.clf = LogisticRegression(max_iter=200)
+            self.clf.fit(X, labels)
+            joblib.dump((self.vectorizer, self.clf), model_path)
+
+    def _extract_slots(self, text: str, command: Command) -> Dict[str, str]:
+        slots = {}
+        for name, pattern in command.slots.items():
+            m = pattern.search(text)
+            if m:
+                slots[name] = m.group(0)
+        return slots
+
+    def predict(self, text: str) -> Tuple[str, Dict[str, str], float]:
+        X = self.vectorizer.transform([text])
+        probs = self.clf.predict_proba(X)[0]
+        idx = probs.argmax()
+        intent = self.clf.classes_[idx]
+        conf = float(probs[idx])
+        command = next((c for c in self.commands if c.id == intent), None)
+        slots: Dict[str, str] = {}
+        if command:
+            slots = self._extract_slots(text, command)
+        if conf < 0.6:
+            intent, slots, conf = self.fuzzy_fallback(text)
+        return intent, slots, conf
+
+    def fuzzy_fallback(self, text: str) -> Tuple[str, Dict[str, str], float]:
+        best_cmd = None
+        best_score = 0
+        for cmd in self.commands:
+            for p in cmd.phrases:
+                score = fuzz.ratio(text.lower(), p.lower()) / 100.0
+                if score > best_score:
+                    best_score = score
+                    best_cmd = cmd
+        if best_cmd and best_score >= 0.5:
+            slots = self._extract_slots(text, best_cmd)
+            return best_cmd.id, slots, best_score
+        return "", {}, best_score
+
+
+def load_commands(path: str) -> List[Command]:
+    with open(path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return [Command(item) for item in data]

--- a/assistant/nlu.py
+++ b/assistant/nlu.py
@@ -6,6 +6,22 @@ from typing import Any, Dict, List, Tuple
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression
 from rapidfuzz import fuzz
+from pathlib import Path
+
+# path to filler words file used for basic text normalisation
+FILLER_FILE = Path(__file__).with_name("filler_words.txt")
+
+
+def normalize(text: str) -> str:
+    """Lowercase and strip filler words from the input."""
+    if FILLER_FILE.exists():
+        with open(FILLER_FILE, "r", encoding="utf-8") as f:
+            fillers = [re.escape(w.strip()) for w in f if w.strip()]
+        if fillers:
+            pattern = re.compile(r"\b(?:" + "|".join(fillers) + r")\b", re.I)
+            text = pattern.sub("", text)
+    text = re.sub(r"\s+", " ", text).strip().lower()
+    return text
 
 
 class Command:

--- a/assistant/requirements.txt
+++ b/assistant/requirements.txt
@@ -1,6 +1,7 @@
 vosk
-pyttsx3
-PyYAML
+piper-tts
+llama-cpp-python
 rapidfuzz
+PyYAML
 scikit-learn
 joblib

--- a/assistant/requirements.txt
+++ b/assistant/requirements.txt
@@ -1,0 +1,6 @@
+vosk
+pyttsx3
+PyYAML
+rapidfuzz
+scikit-learn
+joblib

--- a/assistant/router.py
+++ b/assistant/router.py
@@ -1,0 +1,60 @@
+import json
+import os
+from typing import Callable, Tuple, Dict, Any
+
+from . import actions
+from .nlu import normalize
+from .tools import _REGISTRY
+
+try:
+    from llama_cpp import Llama
+except ImportError:  # pragma: no cover - optional heavy dep
+    Llama = None
+
+
+class Router:
+    """Simple tool selection using an optional local Llama model."""
+
+    def __init__(self, capabilities_path: str = "capabilities.json", model_path: str | None = None):
+        with open(capabilities_path, "r", encoding="utf-8") as f:
+            self.capabilities = json.load(f)
+        if model_path and os.path.exists(model_path) and Llama is not None:
+            self.llm = Llama(model_path=model_path, n_gpu_layers=32)
+        else:
+            self.llm = None
+
+    def _llm_select(self, text: str) -> Tuple[str, Dict[str, Any]]:
+        tools_json = json.dumps(self.capabilities, indent=2)
+        prompt = (
+            "SYSTEM:\nYou are CommandRouter v2. Decide which tool (from TOOLS) best fulfils\n"
+            "the USER request. Respond only with valid JSON:\n"
+            "{\"tool\": \"<tool_name>\", \"args\": {<arg>: <value>}}\n\n"
+            f"TOOLS:\n{tools_json}\n\nUSER: \"{text}\"\n"
+        )
+        output = self.llm(prompt, stop=["\n"])["choices"][0]["text"].strip()
+        try:
+            data = json.loads(output)
+            return data.get("tool"), data.get("args", {})
+        except Exception:
+            return "", {}
+
+    def _heuristic_select(self, text: str) -> Tuple[str, Dict[str, Any]]:
+        text = text.lower()
+        if "download" in text:
+            return "reveal_folder", {"path": os.path.expandvars("%USERPROFILE%/Downloads")}
+        if "youtube" in text:
+            return "open_website", {"url": "youtube.com"}
+        if "open" in text and "website" in text:
+            return "open_website", {"url": text.split()[-1]}
+        return "", {}
+
+    def select(self, text: str) -> Tuple[Callable[..., Tuple[bool, str]], Dict[str, Any]]:
+        text = normalize(text)
+        if self.llm:
+            tool_name, args = self._llm_select(text)
+        else:
+            tool_name, args = self._heuristic_select(text)
+        fn = _REGISTRY.get(tool_name, {}).get("callable")
+        if fn is None:
+            return actions.open_website, {"url": text}
+        return fn, args

--- a/assistant/stt.py
+++ b/assistant/stt.py
@@ -1,0 +1,31 @@
+import asyncio
+import queue
+import threading
+from typing import AsyncGenerator, Optional
+import pyaudio
+
+
+async def speech_chunks(mic_index: Optional[int] = None) -> AsyncGenerator[bytes, None]:
+    """Asynchronously yield microphone audio chunks."""
+    q: queue.Queue[bytes] = queue.Queue()
+
+    def _worker() -> None:
+        pa = pyaudio.PyAudio()
+        stream = pa.open(
+            format=pyaudio.paInt16,
+            channels=1,
+            rate=16000,
+            input=True,
+            input_device_index=mic_index,
+            frames_per_buffer=8000,
+        )
+        stream.start_stream()
+        while True:
+            data = stream.read(4000, exception_on_overflow=False)
+            q.put(data)
+
+    threading.Thread(target=_worker, daemon=True).start()
+    loop = asyncio.get_running_loop()
+    while True:
+        data = await loop.run_in_executor(None, q.get)
+        yield data

--- a/assistant/tools.py
+++ b/assistant/tools.py
@@ -1,0 +1,25 @@
+import inspect
+import json
+import functools
+
+_REGISTRY = {}
+
+def tool(fn):
+    """Decorator registering a callable as an assistant tool."""
+    _REGISTRY[fn.__name__] = {
+        "sig": str(inspect.signature(fn)),
+        "doc": inspect.getdoc(fn) or "",
+        "callable": fn,
+    }
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def export_capabilities(path="capabilities.json"):
+    """Write the registry to a JSON file for introspection."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({k: {"sig": v["sig"], "doc": v["doc"]} for k, v in _REGISTRY.items()}, f, indent=2)

--- a/assistant/tts.py
+++ b/assistant/tts.py
@@ -1,12 +1,42 @@
-import pyttsx3
-from typing import Optional
+"""Wrapper around Piper TTS with simple queuing."""
+
+import subprocess
+import threading
+import queue
+
+_voice = "en-us-kathleen-low"
+_queue: queue.Queue[str] = queue.Queue()
+
+
+def set_voice(name: str) -> None:
+    """Select a different Piper voice model."""
+    global _voice
+    _voice = name
+
+
+def _worker() -> None:
+    while True:
+        text = _queue.get()
+        if text is None:
+            break
+        print(f"Assistant: {text}")
+        subprocess.run([
+            "piper",
+            "--model",
+            _voice,
+            "--text",
+            text,
+        ], check=False)
+        _queue.task_done()
+
+
+_thread = threading.Thread(target=_worker, daemon=True)
+_thread.start()
 
 
 def speak(text: str, enable: bool = True) -> None:
-    """Speak text using pyttsx3 if enabled."""
-    print(f"Assistant: {text}")
+    """Enqueue text to be spoken."""
     if not enable:
+        print(f"Assistant: {text}")
         return
-    engine = pyttsx3.init()
-    engine.say(text)
-    engine.runAndWait()
+    _queue.put(text)

--- a/assistant/tts.py
+++ b/assistant/tts.py
@@ -1,0 +1,12 @@
+import pyttsx3
+from typing import Optional
+
+
+def speak(text: str, enable: bool = True) -> None:
+    """Speak text using pyttsx3 if enabled."""
+    print(f"Assistant: {text}")
+    if not enable:
+        return
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()

--- a/capabilities.json
+++ b/capabilities.json
@@ -1,0 +1,18 @@
+{
+  "open_website": {
+    "sig": "(url: str) -> Tuple[bool, str]",
+    "doc": "Open a website in the default browser."
+  },
+  "launch_app": {
+    "sig": "(path: str) -> Tuple[bool, str]",
+    "doc": "Launch an application given its path."
+  },
+  "search_files": {
+    "sig": "(pattern: str, root: str = '~') -> Tuple[bool, str]",
+    "doc": "Search for files matching pattern under root."
+  },
+  "reveal_folder": {
+    "sig": "(path: str) -> Tuple[bool, str]",
+    "doc": "Open folder in Explorer."
+  }
+}

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,8 @@
+import sys, os; sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from assistant.actions import open_website
+
+
+def test_open_website():
+    success, msg = open_website('example.com')
+    assert success
+    assert 'Opening' in msg

--- a/tests/test_nlu.py
+++ b/tests/test_nlu.py
@@ -1,0 +1,11 @@
+import sys, os; sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from assistant.nlu import load_commands, NLU
+import os
+
+
+def test_nlu_predict(tmp_path):
+    commands = load_commands(os.path.join(os.path.dirname(__file__), '../assistant/commands.yml'))
+    nlu = NLU(commands, model_path=tmp_path/'model.joblib')
+    intent, slots, conf = nlu.predict('open google')
+    assert intent
+    assert conf > 0.0

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,24 @@
+import sys, os, json
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from assistant.router import Router
+from assistant import actions
+
+
+def test_router_polite_phrases(tmp_path):
+    # create minimal capabilities for router
+    Router()  # ensure capabilities.json exists via actions import
+    caps = tmp_path / 'cap.json'
+    with open('capabilities.json', 'r', encoding='utf-8') as f_in:
+        data = json.load(f_in)
+    with open(caps, 'w', encoding='utf-8') as f_out:
+        json.dump(data, f_out)
+
+    router = Router(capabilities_path=str(caps), model_path=None)
+    fn, kwargs = router.select('Could you kindly open YouTube?')
+    assert fn == actions.open_website
+    assert 'youtube' in kwargs.get('url', '')
+
+    fn2, kwargs2 = router.select('Show me my downloads, please')
+    assert fn2 == actions.reveal_folder
+


### PR DESCRIPTION
## Summary
- implement modular voice assistant under `assistant/`
- support simple actions like launching apps or opening websites
- add fuzzy intent prediction and command configuration
- include basic tests for NLU and actions
- update README with Luna usage instructions

## Testing
- `pip install -r assistant/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684832b48e588320a8fed2b0e2740976