### PR TITLE
Add configurable Aurora assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kyra-AI-Assistant
 
-This project contains a simple offline voice assistant and a more modular
-prototype. The original script `nova_assistant.py` listens for **"Hey Nova"**
-and executes a few basic commands. The new `assistant/` package provides a
-more extensible assistant called **Luna** using a wake phrase "Hey Luna".
+This project now provides a lightweight voice assistant called **Aurora**.
+Configuration lives in `config.py` where you can change the wake word,
+default TTS voice and other options.  Tools are pure functions in
+`tools.py` and the main event loop is implemented in `assistant.py`.
 
 ## Requirements
 
@@ -25,8 +25,10 @@ the project directory.
 Run the assistant:
 
 ```bash
-python -m assistant.main --debug --voice en-us-kathleen-low
+python assistant.py
 ```
 
-Say **"Hey Luna"** followed by a polite request. Luna introspects its tools
-from `capabilities.json` and chooses the right action.
+Say the wake phrase (default **"Hey Aurora"**) and then a command such as
+"open youtube.com".  When `DEBUG` is enabled a transcript window will
+appear.  To add new tools simply create a function in `tools.py` and
+register it in the `ALL_TOOLS` dictionary.

--- a/assistant.py
+++ b/assistant.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections import deque
+from typing import Dict, Tuple
+
+import config
+from tools import ALL_TOOLS
+from transcript_console import get_console, TranscriptConsole
+
+try:
+    from vosk import Model, KaldiRecognizer
+    from assistant.stt import speech_chunks  # reuse existing module
+    from assistant.tts import speak, set_voice
+except Exception:  # pragma: no cover - optional heavy deps
+    Model = KaldiRecognizer = None  # type: ignore
+    def speech_chunks(_=None):
+        yield b""
+    def speak(text: str, enable: bool = True):
+        print("Assistant:", text)
+    def set_voice(_name: str) -> None:
+        pass
+
+
+# ----- Intent Parsing ----------------------------------------------------
+_PATTERNS = [
+    (re.compile(r"(?:open|go to) (\S+\.[a-z]{2,})", re.I), "open_website", "url"),
+    (re.compile(r"(?:launch|start) (.+)", re.I), "launch_program", "path"),
+    (re.compile(r"(?:search|find) (.+)", re.I), "search_files", "query"),
+    (re.compile(r"(?:open|show) (.+folder|[a-zA-Z]:\\\\.+)", re.I), "open_explorer", "path"),
+    (re.compile(r"lock (?:pc|computer|screen)", re.I), "lock_pc", None),
+    (re.compile(r"volume up", re.I), "volume_up", None),
+    (re.compile(r"volume down", re.I), "volume_down", None),
+]
+
+
+def detect_wake_word(text: str) -> bool:
+    return text.lower().startswith(config.WAKE_WORD.lower())
+
+
+def parse_intent(text: str) -> Tuple[str, Dict[str, str]]:
+    for pattern, tool, arg in _PATTERNS:
+        m = pattern.search(text)
+        if m:
+            if arg:
+                return tool, {arg: m.group(1)}
+            return tool, {}
+    if re.search(r"\w+\.\w+", text):
+        return "open_website", {"url": text}
+    return "", {}
+
+
+# ----- Execution ---------------------------------------------------------
+_recent: deque[Tuple[int, float]] = deque(maxlen=5)
+
+
+def execute_command(text: str, console: TranscriptConsole) -> str:
+    h = hash(text)
+    now = time.time()
+    if any(h == old and now - t < 2 for old, t in _recent):
+        return ""  # debounce duplicate speech
+    _recent.append((h, now))
+
+    tool, args = parse_intent(text)
+    fn = ALL_TOOLS.get(tool)
+    if not fn:
+        console.log("ERROR", "no_tool")
+        return "Sorry, I couldn't understand."
+    try:
+        result = fn(**args)
+        console.log("BOT", result)
+        return result
+    except Exception as exc:
+        console.log("ERROR", str(exc))
+        return f"Sorry, I couldn't {tool.replace('_', ' ')}."
+
+
+# ----- Main Loop --------------------------------------------------------
+
+def main() -> None:
+    console = get_console()
+    set_voice(config.VOICE)
+    if Model is None:
+        print("Vosk not available")
+        return
+    model = Model(config.OPTIONS.get("model_path", "vosk-model-small-en-us-0.15"))
+    recognizer = KaldiRecognizer(model, 16000)
+    gen = speech_chunks(config.OPTIONS.get("mic_device"))
+    state = "wake"
+    command_text = ""
+    start = 0.0
+    for chunk in gen:
+        if recognizer.AcceptWaveform(chunk):
+            res = json.loads(recognizer.Result())
+            text = res.get("text", "")
+            if not text:
+                continue
+            if state == "wake" and detect_wake_word(text):
+                console.log("USER", text)
+                speak("I'm listening", True)
+                state = "command"
+                start = time.time()
+            elif state == "command":
+                command_text += " " + text
+                if time.time() - start > config.OPTIONS["speech_timeout"]:
+                    console.log("USER", command_text.strip())
+                    reply = execute_command(command_text.strip(), console)
+                    if reply:
+                        speak(reply, True)
+                    command_text = ""
+                    state = "wake"
+
+
+if __name__ == "__main__":
+    main()

--- a/assistant/tools.py
+++ b/assistant/tools.py
@@ -6,15 +6,15 @@ _REGISTRY = {}
 
 def tool(fn):
     """Decorator registering a callable as an assistant tool."""
-    _REGISTRY[fn.__name__] = {
-        "sig": str(inspect.signature(fn)),
-        "doc": inspect.getdoc(fn) or "",
-        "callable": fn,
-    }
-
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         return fn(*args, **kwargs)
+
+    _REGISTRY[fn.__name__] = {
+        "sig": str(inspect.signature(fn)),
+        "doc": inspect.getdoc(fn) or "",
+        "callable": wrapper,
+    }
 
     return wrapper
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+WAKE_WORD = "Hey Aurora"
+VOICE = "en_US-libritts-high"
+DEBUG = True
+
+OPTIONS = {
+    "speech_timeout": 6,
+    "mic_device": None,
+}

--- a/tests/test_aurora.py
+++ b/tests/test_aurora.py
@@ -1,0 +1,39 @@
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(ROOT, path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    return mod
+
+assistant = load_module("assistant_module", "assistant.py")
+config = load_module("config_module", "config.py")
+console_mod = load_module("console_module", "transcript_console.py")
+
+
+def test_intent_parser():
+    tool, args = assistant.parse_intent("open github.com")
+    assert tool == "open_website"
+    assert args["url"] == "github.com"
+
+
+def test_wake_word(monkeypatch):
+    monkeypatch.setattr(assistant.config, "WAKE_WORD", "Hey Test")
+    monkeypatch.setattr(config, "WAKE_WORD", "Hey Test")
+    assert assistant.detect_wake_word("Hey Test open")
+    assert not assistant.detect_wake_word("Hello there")
+
+
+def test_console_toggle(monkeypatch):
+    monkeypatch.setattr(assistant.config, "DEBUG", True)
+    monkeypatch.setattr(config, "DEBUG", True)
+    console = console_mod.get_console()
+    assert getattr(console, "enabled", False)
+    monkeypatch.setattr(assistant.config, "DEBUG", False)
+    monkeypatch.setattr(config, "DEBUG", False)
+    console = console_mod.get_console()
+    assert not getattr(console, "enabled", False)

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+import webbrowser
+from pathlib import Path
+from typing import Dict, Callable
+
+
+def open_website(url: str) -> str:
+    if not url.startswith("http"):
+        url = "https://" + url
+    webbrowser.open_new_tab(url)
+    return f"Opening {url}"
+
+
+def launch_program(path: str) -> str:
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise FileNotFoundError(path)
+    try:
+        os.startfile(str(p))  # type: ignore[attr-defined]
+    except Exception:
+        subprocess.Popen([str(p)])
+    return f"Launching {p}"
+
+
+def search_files(query: str) -> str:
+    root = Path.home()
+    matches = [str(p) for p in root.rglob(f"*{query}*")][:5]
+    if not matches:
+        return "No files found"
+    return "Found: " + "; ".join(matches)
+
+
+def open_explorer(path: str) -> str:
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise FileNotFoundError(path)
+    try:
+        os.startfile(str(p))  # type: ignore[attr-defined]
+    except Exception:
+        subprocess.Popen(["xdg-open", str(p)])
+    return f"Opening {p}"
+
+
+def lock_pc() -> str:
+    if os.name == "nt":
+        subprocess.call(["rundll32.exe", "user32.dll,LockWorkStation"])
+    elif sys.platform == "darwin":
+        subprocess.call(["osascript", "-e", 'tell application "System Events" to keystroke "q" using {control down, command down}'])
+    else:
+        subprocess.call(["gnome-screensaver-command", "--lock"])
+    return "Locking workstation"
+
+
+def volume_up() -> str:
+    if os.name == "nt":
+        subprocess.call(["nircmd.exe", "changesysvolume", "2000"])
+    else:
+        subprocess.call(["pactl", "set-sink-volume", "@DEFAULT_SINK@", "+5%"])
+    return "Volume up"
+
+
+def volume_down() -> str:
+    if os.name == "nt":
+        subprocess.call(["nircmd.exe", "changesysvolume", "-2000"])
+    else:
+        subprocess.call(["pactl", "set-sink-volume", "@DEFAULT_SINK@", "-5%"])
+    return "Volume down"
+
+
+ALL_TOOLS: Dict[str, Callable[..., str]] = {
+    "open_website": open_website,
+    "launch_program": launch_program,
+    "search_files": search_files,
+    "open_explorer": open_explorer,
+    "lock_pc": lock_pc,
+    "volume_up": volume_up,
+    "volume_down": volume_down,
+}

--- a/transcript_console.py
+++ b/transcript_console.py
@@ -1,0 +1,62 @@
+import threading
+import time
+import curses
+import config
+
+
+class TranscriptConsole:
+    """Simple curses-based transcript window."""
+
+    def __init__(self) -> None:
+        self.enabled = bool(config.DEBUG)
+        self.lines: list[tuple[str, str]] = []
+        if not self.enabled:
+            return
+        self.lock = threading.Lock()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def log(self, speaker: str, text: str) -> None:
+        if not self.enabled:
+            return
+        with self.lock:
+            ts = time.strftime("%H:%M:%S")
+            self.lines.append((f"[{ts}] {speaker}: ", text))
+            if len(self.lines) > 50:
+                self.lines = self.lines[-50:]
+
+    def _run(self) -> None:
+        stdscr = curses.initscr()
+        curses.start_color()
+        curses.use_default_colors()
+        curses.init_pair(1, curses.COLOR_GREEN, -1)
+        curses.init_pair(2, curses.COLOR_CYAN, -1)
+        curses.init_pair(3, curses.COLOR_RED, -1)
+        while True:
+            with self.lock:
+                stdscr.erase()
+                h, _ = stdscr.getmaxyx()
+                start = max(len(self.lines) - h, 0)
+                for idx, (prefix, msg) in enumerate(self.lines[start:]):
+                    color = 1 if prefix.strip().startswith("USER") else 2
+                    if prefix.strip().startswith("ERROR"):
+                        color = 3
+                    stdscr.addstr(idx, 0, prefix + msg, curses.color_pair(color))
+                stdscr.refresh()
+            time.sleep(0.5)
+
+
+class NoopConsole:
+    def log(self, *_: str) -> None:  # pragma: no cover - simple noop
+        pass
+
+
+def get_console() -> TranscriptConsole:
+    """Factory respecting config.DEBUG."""
+    if config.DEBUG:
+        return TranscriptConsole()
+    return NoopConsole()  # type: ignore
+
+if __name__ == "__main__":
+    from assistant import main
+    main()


### PR DESCRIPTION
## Summary
- implement new `assistant.py` with wake-word detection and command routing
- add `config.py` for assistant options
- add pure function helpers in `tools.py`
- create `transcript_console.py` with debug console
- document usage in README
- provide unit tests for intent parsing, wake-word handling and console toggle
- tweak tool registry to return decorated functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483c4d65cc83209e8c0601f5fd7331