### PR TITLE
Add semantic NLU and tool router

### DIFF
--- a/assistant/filler_words.txt
+++ b/assistant/filler_words.txt
@@ -4,3 +4,5 @@ would you kindly
 can you
 please,
 kindly
+would you
+for me

--- a/assistant/main.py
+++ b/assistant/main.py
@@ -3,18 +3,47 @@ import asyncio
 import json
 import logging
 import os
+from typing import Any
 
 from vosk import KaldiRecognizer, Model
 
 from .stt import speech_chunks
 from .router import Router
 from .tts import speak, set_voice
+from .nlu import normalize
 
 logging.basicConfig(
     filename="assistant.log",
     level=logging.INFO,
     format="%(asctime)s %(levelname)s:%(message)s",
 )
+
+
+class Logger:
+    def __init__(self, debug: bool = False):
+        self.debug = debug
+        try:
+            from colorama import Fore, Style
+
+            self.colors = {
+                "USER": Fore.CYAN,
+                "NORM": Fore.MAGENTA,
+                "NLU": Fore.YELLOW,
+                "CALL": Fore.GREEN,
+                "RESP": Fore.BLUE,
+                "ERR": Fore.RED,
+            }
+            self.reset = Style.RESET_ALL
+        except Exception:  # pragma: no cover - colorama optional
+            self.colors = {t: "" for t in ["USER", "NORM", "NLU", "CALL", "RESP", "ERR"]}
+            self.reset = ""
+
+    def log(self, tag: str, message: str) -> None:
+        if not self.debug:
+            return
+        color = self.colors.get(tag, "")
+        print(f"[{tag:4}] {color}{message}{self.reset}")
+
 
 WAKE_WORD = "hey luna"
 MODEL_PATH = "vosk-model-small-en-us-0.15"
@@ -29,12 +58,22 @@ async def load_stt() -> KaldiRecognizer:
     return KaldiRecognizer(model, 16000)
 
 
-async def handle_command(text: str, router: Router, tts_enabled: bool) -> None:
-    tool_fn, kwargs = router.select(text)
-    ok, msg = tool_fn(**kwargs)
-    speak(msg, tts_enabled)
-    if not ok:
-        logging.error("Action failed: %s", msg)
+async def handle_command(text: str, router: Router, tts_enabled: bool, logger: Logger) -> None:
+    norm = normalize(text)
+    fn, args, intent, conf = router.select(text)
+    logger.log("NORM", f'"{norm}"')
+    logger.log("NLU", f"intent={intent}, args={args}, conf={conf:.2f}")
+    if fn:
+        ok, msg = fn(**args)
+        status = "\u2713" if ok else "x"
+        logger.log("CALL", f"actions.{fn.__name__}({args}) -> {status} {msg}")
+        speak(msg, tts_enabled)
+        if not ok:
+            logger.log("ERR", msg)
+    else:
+        resp = "I'm sorry, I didn't understand."  # placeholder response
+        logger.log("RESP", resp)
+        speak(resp, tts_enabled)
 
 
 async def main() -> None:
@@ -45,13 +84,13 @@ async def main() -> None:
     parser.add_argument("--voice", default="en-us-kathleen-low")
     args = parser.parse_args()
 
+    logger = Logger(debug=args.debug)
     set_voice(args.voice)
     router = Router()
     recognizer = await load_stt()
 
     gen = speech_chunks(args.mic_index)
     state = "wake"
-    command_text = ""
     async for chunk in gen:
         if recognizer.AcceptWaveform(chunk):
             res = json.loads(recognizer.Result())
@@ -62,8 +101,8 @@ async def main() -> None:
                 speak("I'm listening", not args.headless)
                 state = "command"
             elif state == "command" and text:
-                command_text = text
-                await handle_command(command_text, router, not args.headless)
+                logger.log("USER", text)
+                await handle_command(text, router, not args.headless, logger)
                 state = "wake"
 
 

--- a/assistant/nlu.py
+++ b/assistant/nlu.py
@@ -1,97 +1,138 @@
 import os
 import re
-import yaml
-import joblib
-from typing import Any, Dict, List, Tuple
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.linear_model import LogisticRegression
-from rapidfuzz import fuzz
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+from rapidfuzz.fuzz import token_set_ratio
 
 # path to filler words file used for basic text normalisation
 FILLER_FILE = Path(__file__).with_name("filler_words.txt")
 
 
 def normalize(text: str) -> str:
-    """Lowercase and strip filler words from the input."""
+    """Lowercase, remove punctuation and filler words."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)
     if FILLER_FILE.exists():
         with open(FILLER_FILE, "r", encoding="utf-8") as f:
             fillers = [re.escape(w.strip()) for w in f if w.strip()]
         if fillers:
             pattern = re.compile(r"\b(?:" + "|".join(fillers) + r")\b", re.I)
             text = pattern.sub("", text)
-    text = re.sub(r"\s+", " ", text).strip().lower()
+    text = re.sub(r"\s+", " ", text).strip()
     return text
 
 
-class Command:
-    def __init__(self, data: Dict[str, Any]):
-        self.id = data['id']
-        self.phrases = data.get('phrases', [])
-        self.slots = {name: re.compile(pattern, re.I) for name, pattern in data.get('slots', {}).items()}
-        self.action = data['action']
-        self.args = data.get('args', {})
+@dataclass
+class Intent:
+    id: str
+    patterns: List[re.Pattern]
+    canonical: str
+    synonyms: List[str]
+    extractor: Callable[[re.Match], Dict[str, str]]
 
 
-class NLU:
-    def __init__(self, commands: List[Command], model_path: str = 'nlu.joblib'):
-        self.commands = commands
-        self.model_path = model_path
-        texts = []
-        labels = []
-        for cmd in commands:
-            for p in cmd.phrases:
-                # replace slot markers with the slot name so the model can generalise
-                processed = re.sub(r"{(\w+)}", r"\1", p)
-                texts.append(processed)
-                labels.append(cmd.id)
-        if os.path.exists(model_path):
-            self.vectorizer, self.clf = joblib.load(model_path)
-        else:
-            self.vectorizer = TfidfVectorizer()
-            X = self.vectorizer.fit_transform(texts)
-            self.clf = LogisticRegression(max_iter=200)
-            self.clf.fit(X, labels)
-            joblib.dump((self.vectorizer, self.clf), model_path)
+INTENTS: List[Intent] = []
 
-    def _extract_slots(self, text: str, command: Command) -> Dict[str, str]:
-        slots = {}
-        for name, pattern in command.slots.items():
-            m = pattern.search(text)
+
+def _register_intents() -> None:
+    def site_extract(m: re.Match) -> Dict[str, str]:
+        site = m.group("site").strip().lower()
+        site = re.sub(r"^the\s+", "", site)
+        if not re.search(r"\.[a-z]{2,}$", site):
+            site += ".com"
+        return {"url": site}
+
+    INTENTS.append(
+        Intent(
+            id="open_website",
+            patterns=[
+                re.compile(r"(?:open|go to|pull up|visit)\s+(?:the\s+)?(?P<site>[\w\.-]+)", re.I)
+            ],
+            canonical="open website",
+            synonyms=["go to site", "pull up site"],
+            extractor=site_extract,
+        )
+    )
+
+    def app_extract(m: re.Match) -> Dict[str, str]:
+        name = m.group("app").strip().lower()
+        mapping = {
+            "calculator": "calc.exe",
+            "calc": "calc.exe",
+            "discord": "discord.exe",
+            "notepad": "notepad.exe",
+        }
+        path = mapping.get(name, name)
+        return {"path": path}
+
+    INTENTS.append(
+        Intent(
+            id="launch_app",
+            patterns=[re.compile(r"(?:open|launch|start)\s+(?P<app>[\w\s]+)", re.I)],
+            canonical="launch app",
+            synonyms=["open app", "start app"],
+            extractor=app_extract,
+        )
+    )
+
+    def search_extract(m: re.Match) -> Dict[str, str]:
+        query = m.group("query").strip()
+        return {"query": query}
+
+    INTENTS.append(
+        Intent(
+            id="search_files",
+            patterns=[re.compile(r"(?:find file|search for)\s+(?P<query>.+)", re.I)],
+            canonical="search files",
+            synonyms=["find file", "search for file"],
+            extractor=search_extract,
+        )
+    )
+
+    def folder_extract(m: re.Match) -> Dict[str, str]:
+        folder = m.group("folder").lower()
+        mapping = {"downloads": os.path.expandvars("%USERPROFILE%/Downloads")}
+        path = mapping.get(folder, folder)
+        return {"path": path}
+
+    INTENTS.append(
+        Intent(
+            id="reveal_folder",
+            patterns=[re.compile(r"(?:open|show)(?: my)? (?P<folder>downloads)(?: folder)?", re.I)],
+            canonical="open downloads folder",
+            synonyms=["show my downloads folder", "open downloads"],
+            extractor=folder_extract,
+        )
+    )
+
+
+_register_intents()
+
+
+def classify(text: str) -> Tuple[str, Dict[str, str], float]:
+    norm = normalize(text)
+
+    # pass 1: regex patterns
+    for intent in INTENTS:
+        for pat in intent.patterns:
+            m = pat.search(norm)
             if m:
-                slots[name] = m.group(0)
-        return slots
+                args = intent.extractor(m)
+                return intent.id, args, 1.0
 
-    def predict(self, text: str) -> Tuple[str, Dict[str, str], float]:
-        X = self.vectorizer.transform([text])
-        probs = self.clf.predict_proba(X)[0]
-        idx = probs.argmax()
-        intent = self.clf.classes_[idx]
-        conf = float(probs[idx])
-        command = next((c for c in self.commands if c.id == intent), None)
-        slots: Dict[str, str] = {}
-        if command:
-            slots = self._extract_slots(text, command)
-        if conf < 0.6:
-            intent, slots, conf = self.fuzzy_fallback(text)
-        return intent, slots, conf
+    # pass 2: fuzzy similarity
+    best_intent = None
+    best_score = 0
+    for intent in INTENTS:
+        for phrase in [intent.canonical] + intent.synonyms:
+            score = token_set_ratio(norm, phrase)
+            if score > best_score:
+                best_score = score
+                best_intent = intent
 
-    def fuzzy_fallback(self, text: str) -> Tuple[str, Dict[str, str], float]:
-        best_cmd = None
-        best_score = 0
-        for cmd in self.commands:
-            for p in cmd.phrases:
-                score = fuzz.ratio(text.lower(), p.lower()) / 100.0
-                if score > best_score:
-                    best_score = score
-                    best_cmd = cmd
-        if best_cmd and best_score >= 0.5:
-            slots = self._extract_slots(text, best_cmd)
-            return best_cmd.id, slots, best_score
-        return "", {}, best_score
-
-
-def load_commands(path: str) -> List[Command]:
-    with open(path, 'r', encoding='utf-8') as f:
-        data = yaml.safe_load(f)
-    return [Command(item) for item in data]
+    confidence = best_score / 100.0
+    if best_intent is None:
+        return "chat", {}, 0.0
+    return best_intent.id, {}, confidence

--- a/assistant/requirements.txt
+++ b/assistant/requirements.txt
@@ -1,7 +1,8 @@
 vosk
 piper-tts
 llama-cpp-python
-rapidfuzz
+rapidfuzz==3.*
+
 PyYAML
 scikit-learn
 joblib

--- a/assistant/router.py
+++ b/assistant/router.py
@@ -1,60 +1,16 @@
-import json
-import os
-from typing import Callable, Tuple, Dict, Any
+from typing import Any, Callable, Dict, Tuple
 
 from . import actions
-from .nlu import normalize
+from .nlu import classify
 from .tools import _REGISTRY
-
-try:
-    from llama_cpp import Llama
-except ImportError:  # pragma: no cover - optional heavy dep
-    Llama = None
 
 
 class Router:
-    """Simple tool selection using an optional local Llama model."""
+    """Route user text to an action function based on NLU classification."""
 
-    def __init__(self, capabilities_path: str = "capabilities.json", model_path: str | None = None):
-        with open(capabilities_path, "r", encoding="utf-8") as f:
-            self.capabilities = json.load(f)
-        if model_path and os.path.exists(model_path) and Llama is not None:
-            self.llm = Llama(model_path=model_path, n_gpu_layers=32)
-        else:
-            self.llm = None
-
-    def _llm_select(self, text: str) -> Tuple[str, Dict[str, Any]]:
-        tools_json = json.dumps(self.capabilities, indent=2)
-        prompt = (
-            "SYSTEM:\nYou are CommandRouter v2. Decide which tool (from TOOLS) best fulfils\n"
-            "the USER request. Respond only with valid JSON:\n"
-            "{\"tool\": \"<tool_name>\", \"args\": {<arg>: <value>}}\n\n"
-            f"TOOLS:\n{tools_json}\n\nUSER: \"{text}\"\n"
-        )
-        output = self.llm(prompt, stop=["\n"])["choices"][0]["text"].strip()
-        try:
-            data = json.loads(output)
-            return data.get("tool"), data.get("args", {})
-        except Exception:
-            return "", {}
-
-    def _heuristic_select(self, text: str) -> Tuple[str, Dict[str, Any]]:
-        text = text.lower()
-        if "download" in text:
-            return "reveal_folder", {"path": os.path.expandvars("%USERPROFILE%/Downloads")}
-        if "youtube" in text:
-            return "open_website", {"url": "youtube.com"}
-        if "open" in text and "website" in text:
-            return "open_website", {"url": text.split()[-1]}
-        return "", {}
-
-    def select(self, text: str) -> Tuple[Callable[..., Tuple[bool, str]], Dict[str, Any]]:
-        text = normalize(text)
-        if self.llm:
-            tool_name, args = self._llm_select(text)
-        else:
-            tool_name, args = self._heuristic_select(text)
-        fn = _REGISTRY.get(tool_name, {}).get("callable")
-        if fn is None:
-            return actions.open_website, {"url": text}
-        return fn, args
+    def select(self, text: str) -> Tuple[Callable[..., Tuple[bool, str]] | None, Dict[str, Any], str, float]:
+        intent, args, conf = classify(text)
+        fn = None
+        if intent != "chat" and conf >= 0.75:
+            fn = _REGISTRY.get(intent, {}).get("callable")
+        return fn, args, intent, conf

--- a/tests/test_nlu.py
+++ b/tests/test_nlu.py
@@ -1,11 +1,10 @@
 import sys, os; sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from assistant.nlu import load_commands, NLU
-import os
+
+from assistant.nlu import classify
 
 
-def test_nlu_predict(tmp_path):
-    commands = load_commands(os.path.join(os.path.dirname(__file__), '../assistant/commands.yml'))
-    nlu = NLU(commands, model_path=tmp_path/'model.joblib')
-    intent, slots, conf = nlu.predict('open google')
-    assert intent
-    assert conf > 0.0
+def test_nlu_classify_open_website():
+    intent, args, conf = classify("please open youtube")
+    assert intent == "open_website"
+    assert args.get("url") == "youtube.com"
+    assert conf >= 0.75

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,24 +1,20 @@
-import sys, os, json
+import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from assistant.router import Router
 from assistant import actions
 
 
-def test_router_polite_phrases(tmp_path):
-    # create minimal capabilities for router
-    Router()  # ensure capabilities.json exists via actions import
-    caps = tmp_path / 'cap.json'
-    with open('capabilities.json', 'r', encoding='utf-8') as f_in:
-        data = json.load(f_in)
-    with open(caps, 'w', encoding='utf-8') as f_out:
-        json.dump(data, f_out)
+def test_router_polite_phrases():
+    router = Router()
+    fn, kwargs, intent, conf = router.select('Could you kindly open YouTube?')
+    assert fn is not None
+    assert fn.__name__ == actions.open_website.__name__
+    assert kwargs.get('url') == 'youtube.com'
+    assert intent == 'open_website'
+    assert conf >= 0.75
 
-    router = Router(capabilities_path=str(caps), model_path=None)
-    fn, kwargs = router.select('Could you kindly open YouTube?')
-    assert fn == actions.open_website
-    assert 'youtube' in kwargs.get('url', '')
-
-    fn2, kwargs2 = router.select('Show me my downloads, please')
-    assert fn2 == actions.reveal_folder
-
+    fn2, kwargs2, intent2, _ = router.select('Show me my downloads, please')
+    assert fn2 is not None
+    assert fn2.__name__ == actions.reveal_folder.__name__
+    assert intent2 == 'reveal_folder'


### PR DESCRIPTION
## Summary
- enhance filler words list
- improve intent classification with fuzzy matching
- route commands through the new NLU
- add verbose logging in main
- pin rapidfuzz dependency
- update tests for new NLU/Router

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684843b37a908320a77821a635ed9b67