### PR TITLE
Fix search_files() TypeError & add Kyra CLI command

### DIFF
--- a/README_CLIBOOT.md
+++ b/README_CLIBOOT.md
@@ -1,0 +1,17 @@
+To use the `Kyra` command line tool on Windows:
+
+1. Install the project in editable mode:
+   ```cmd
+   pip install -e .
+   ```
+
+2. Ensure the directory where pip installs scripts is in your `%PATH%`.
+   For a typical user install this is:
+   `%APPDATA%\Python\Scripts`
+   (or the path printed by `pip -V`).
+
+With that setup you can run commands such as:
+```cmd
+Kyra open youtube
+```
+which invokes the assistant on the provided text.

--- a/core/tools.py
+++ b/core/tools.py
@@ -126,9 +126,9 @@ def launch_app(path: str) -> Tuple[bool, str]:
 
 
 @tool
-def search_files(pattern: str, root: str = "~") -> Tuple[bool, str]:
+def search_files(directory: str, pattern: str, **_unused: Any) -> Tuple[bool, str]:
     """Search for files under a directory."""
-    root = os.path.expanduser(root)
+    root = os.path.expanduser(directory)
     glob_pattern = derive_glob_from_phrase(pattern)
     matches: List[str] = []
     for dirpath, _dirs, files in os.walk(root):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = kyra-assistant
+version = 0.0.0
+
+[options]
+packages = find:
+install_requires =
+    vosk
+    requests
+    pydantic
+    gTTS
+    playsound==1.2.2
+    rapidfuzz
+    jsonschema
+python_requires = >=3.10
+
+[options.entry_points]
+console_scripts =
+    Kyra = app.assistant:main


### PR DESCRIPTION
## Summary
- make `search_files` accept the directory argument the router emits
- support one-shot command execution in `app.assistant`
- ship a `setup.cfg` with console entry point
- add Windows CLI install instructions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489a6aecb883208d76a99abdc4d84c