### PR TITLE
Fix empty LLM replies in voice mode

### DIFF
--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -1,0 +1,13 @@
+import os, sys, types
+
+# Provide stub pyaudio so importing speak doesn't require system deps
+sys.modules['pyaudio'] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.assistant import speak
+
+
+def test_speak_empty(monkeypatch):
+    monkeypatch.setattr("app.assistant.gTTS", lambda _: _)
+    speak("", True)
+    speak("   ", True)


### PR DESCRIPTION
## Summary
- avoid sending blank strings to gTTS
- handle gTTS AssertionError failures
- test speak() with empty input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ad91598483208b45487f3405e725