### PR TITLE
feat: speak concise confirmation for tool calls & add graceful fallback

### DIFF
--- a/app/assistant.py
+++ b/app/assistant.py
@@ -22,6 +22,28 @@ from core.tools import _REGISTRY
 logger = logging.getLogger(__name__)
 
 
+def summarise_router_reply(reply: str) -> str:
+    """Return a short sentence for TTS or fallback message."""
+    try:
+        obj = json.loads(reply)
+    except Exception:
+        return "I was unable to get that."
+
+    name = obj.get("function", {}).get("name")
+    args = obj.get("arguments", {})
+
+    if name == "open_website":
+        url = args.get("url", "")
+        site = url.split("//")[-1].split("/")[0] or url
+        return f"Opening {site}"
+    elif name == "launch_app":
+        return f"Launching {args.get('app', 'application')}"
+    elif name == "search_files":
+        return "Searching files"
+    else:
+        return "I was unable to get that."
+
+
 async def microphone_chunks() -> AsyncGenerator[bytes, None]:
     q: asyncio.Queue[bytes] = asyncio.Queue()
     loop = asyncio.get_running_loop()
@@ -98,7 +120,8 @@ async def voice_loop(
             else:
                 reply = args.get("content", "I didn't understand")
                 transcript.log("BOT", reply)
-                speak(reply, tts)
+                spoken = summarise_router_reply(reply)
+                speak(spoken, tts)
 
 
 async def console_loop(router: IntentRouter, transcript: Transcript) -> None:

--- a/tests/test_router_summary.py
+++ b/tests/test_router_summary.py
@@ -1,0 +1,17 @@
+import os, sys, types
+
+# Stub pyaudio so importing assistant works without system deps
+sys.modules['pyaudio'] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+
+from app.assistant import summarise_router_reply
+
+
+def test_open_website():
+    assert summarise_router_reply(
+        '{"function":{"name":"open_website"},"arguments":{"url":"https://www.google.com"}}'
+    ) == "Opening www.google.com"
+
+
+def test_invalid_json():
+    assert summarise_router_reply('') == "I was unable to get that."
+


### PR DESCRIPTION
## Summary
- add `summarise_router_reply` helper to derive short phrases from router JSON
- use the new helper in `voice_loop` to verbalise concise confirmations
- cover parsing logic with new tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848af49a9c083209d46cadb1ae8564a