### PR TITLE
feat: speak concise confirmation for tool calls & add graceful fallback

### DIFF
--- a/tests/test_router_summary.py
+++ b/tests/test_router_summary.py
@@ -1,0 +1,19 @@
+import sys
+import types
+
+# Stub pyaudio so importing assistant works without system deps
+sys.modules["pyaudio"] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+
+from app.assistant import summarise_router_reply  # noqa: E402
+
+
+def test_open_website():
+    data = (
+        '{"function":{"name":"open_website"},'
+        '"arguments":{"url":"https://www.google.com"}}'
+    )
+    assert summarise_router_reply(data) == "Opening www.google.com"
+
+
+def test_invalid_json():
+    assert summarise_router_reply('') == "I was unable to get that."


### PR DESCRIPTION
## Summary
- implement `summarise_router_reply` helper for parsing router JSON replies
- use the helper in `voice_loop` so speech is short and user-friendly
- add tests covering the new summary behaviour

## Testing
- `pip install -r requirements.txt`
- `flake8 app/assistant.py tests/test_router_summary.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848af49a9c083209d46cadb1ae8564a