### PR TITLE
feat: speak concise confirmation for tool calls & add graceful fallback

### DIFF
--- a/tests/test_router_summary.py
+++ b/tests/test_router_summary.py
@@ -1,0 +1,27 @@
+import sys
+import types
+
+# Stub pyaudio so importing assistant works without system deps
+sys.modules["pyaudio"] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+
+from app.assistant import summarise_router_reply  # noqa: E402
+
+
+def test_open_website():
+    data = (
+        '{"function":{"name":"open_website"},'
+        '"arguments":{"url":"https://www.google.com"}}'
+    )
+    assert summarise_router_reply(data) == "Opening www.google.com"
+
+
+def test_launch_app():
+    data = (
+        '{"function":{"name":"launch_app"},'
+        '"arguments":{"app":"notepad"}}'
+    )
+    assert summarise_router_reply(data) == "Launching notepad"
+
+
+def test_invalid_json():
+    assert summarise_router_reply('') == "I was unable to get that."

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,13 +1,21 @@
-import os, sys
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from core import tools
+from core import tools  # noqa: E402
 
 
 def test_open_website():
     success, msg = tools.open_website("example.com")
     assert success
     assert "Opening" in msg
+
+
+def test_launch_app(monkeypatch):
+    monkeypatch.setattr(tools.subprocess, "Popen", lambda *_: None)
+    success, msg = tools.launch_app("dummy")
+    assert success
+    assert msg == "Launching dummy"
 
 
 def test_derive_glob_from_phrase():


### PR DESCRIPTION
## Summary
- implement `summarise_router_reply` helper for parsing router JSON replies
- use the helper in `voice_loop` so speech is short and user-friendly
- add tests covering the new summary behaviour
- fix launch_app parameter mismatch with router

## Testing
- `pip install -r requirements.txt`
- `flake8 app/assistant.py core/tools.py tests/test_router_summary.py tests/test_tools.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848af49a9c083209d46cadb1ae8564a