### PR TITLE
Improve intent handling and add music feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This project provides an offline voice assistant powered by local models.
    ```bash
    python -m app.assistant --mode voice
    ```
+   Use `--mode text` to interact via the console only.
+
+The assistant reads optional settings from `config.json` where you can
+customise the wake word, enable debug logging and choose the TTS engine.
 
 This project uses [gTTS](https://gtts.readthedocs.io/) for text-to-speech
 output.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "wake_word": "Hey Aurora",
+  "debug": true,
+  "tts_engine": "gtts"
+}

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,29 @@
+"""Basic runtime configuration loaded from ``config.json`` if present."""
+
+import json
+import os
+
 LLM_BASE_URL = "http://localhost:11434/v1/chat"
 MODEL_NAME = "mistral:7b-instruct"
-WAKE_WORD = "Hey Aurora"
-DEBUG = True
+
+_DEFAULT = {
+    "wake_word": "Hey Aurora",
+    "debug": True,
+    "tts_engine": "gtts",
+}
+
+_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config.json")
+
+try:  # pragma: no cover - file may not exist in tests
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+        _USER = json.load(f)
+except Exception:
+    _USER = {}
+
+_CONFIG = {**_DEFAULT, **_USER}
+
+WAKE_WORD: str = _CONFIG.get("wake_word", _DEFAULT["wake_word"])
+DEBUG: bool = bool(_CONFIG.get("debug", _DEFAULT["debug"]))
+TTS_ENGINE: str = _CONFIG.get("tts_engine", _DEFAULT["tts_engine"])
+
+__all__ = ["LLM_BASE_URL", "MODEL_NAME", "WAKE_WORD", "DEBUG", "TTS_ENGINE"]

--- a/core/dispatcher.py
+++ b/core/dispatcher.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+from typing import Dict, Tuple, Optional
+
+from rapidfuzz import fuzz
+
+from .tools import sanitize_domain
+
+logger = logging.getLogger(__name__)
+
+FILLER_RE = re.compile(r"\b(?:please|can you|could you|would you|i want to|i wanna|i want|\s+)\b", re.I)
+
+
+def _clean(text: str) -> str:
+    text = text.lower().strip()
+    text = FILLER_RE.sub(" ", text)
+    return re.sub(r"\s+", " ", text)
+
+
+def match_intent(text: str) -> Tuple[Optional[str], Dict[str, str]]:
+    """Return tool name and arguments if recognised."""
+    cleaned = _clean(text)
+
+    m = re.search(r"(?:play|listen to|hear) (?P<song>.+)", cleaned)
+    if m:
+        song = re.sub(r" on youtube$", "", m.group("song"), flags=re.I).strip()
+        logger.debug("Mapped input '%s' to play_music with arg: '%s'", text, song)
+        return "play_music", {"song": song}
+
+    m = re.search(r"(?:search for|look up) (?P<query>.+)", cleaned)
+    if m:
+        q = m.group("query").strip()
+        url = f"https://www.google.com/search?q={urllib.parse.quote(q)}"
+        logger.debug("Mapped input '%s' to open_website search with arg: '%s'", text, q)
+        return "open_website", {"url": url}
+
+    m = re.search(r"(?:open|visit|go to) (?P<site>.+)", cleaned)
+    if m:
+        site = m.group("site").strip()
+        logger.debug("Mapped input '%s' to open_website with arg: '%s'", text, site)
+        return "open_website", {"url": site}
+
+    # Similarity fallback for one-word commands
+    scores = {
+        "open_website": fuzz.partial_ratio(cleaned, "open"),
+        "play_music": fuzz.partial_ratio(cleaned, "play"),
+        "open_search": fuzz.partial_ratio(cleaned, "search"),
+    }
+    best = max(scores, key=scores.get)
+    if scores[best] > 60:
+        if best == "open_search":
+            url = f"https://www.google.com/search?q={urllib.parse.quote(cleaned)}"
+            return "open_website", {"url": url}
+        elif best == "open_website":
+            dom = sanitize_domain(cleaned)
+            arg = dom if dom else cleaned
+            return "open_website", {"url": arg}
+        else:
+            return "play_music", {"song": cleaned}
+
+    return None, {}
+

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,21 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from core.dispatcher import match_intent
+
+
+def test_match_play():
+    name, args = match_intent("please play Bohemian Rhapsody on youtube")
+    assert name == "play_music"
+    assert args["song"] == "bohemian rhapsody"
+
+
+def test_match_search():
+    name, args = match_intent("Search for openai")
+    assert name == "open_website"
+    assert "openai" in args["url"]
+
+
+def test_match_open():
+    name, args = match_intent("Can you open google.com")
+    assert name == "open_website"
+    assert args["url"] == "google.com"

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,8 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from core.tools import sanitize_domain
+
+
+def test_sanitize():
+    assert sanitize_domain('https://WWW.Google.com/search') == 'google.com'
+    assert sanitize_domain('play this song') == ''


### PR DESCRIPTION
## Summary
- load configuration from `config.json`
- sanitize domain names and add fallback search
- add `play_music` tool and dispatcher for simple text commands
- route console and voice input through new dispatcher
- document text mode and config file
- test dispatcher and sanitiser helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b94e952483208de0a10ab2f49b9e