### PR TITLE
Add new play_music tool and router improvements

### DIFF
--- a/app/assistant.py
+++ b/app/assistant.py
@@ -13,31 +13,65 @@ from playsound import playsound
 from vosk import Model, KaldiRecognizer
 import logging
 import re
+import urllib.parse
+import webbrowser
 
 from core.config import DEBUG, WAKE_WORD, TTS_ENGINE
 from core.intent_router import IntentRouter
 from core.transcript import Transcript
 
-from core.tools import _REGISTRY
+from core.tools import _REGISTRY, tool, _TOOL_SCHEMA_MAP
 from core.dispatcher import match_intent
 
 ROUTER_PROMPT = """
-You are an intent-router for a local voice assistant.
-Return **only** this JSON schema — no prose, no code fences:
+You are an intent‑router for a local voice assistant.
+
+Respond with **ONLY** a JSON object like one of these — no prose, no markdown:
+
+{ "function": null }
+
+or
 
 {
   "function": {
     "name": "<one_of_the_function_names_provided>",
-    "arguments": { ... }
+    "arguments": { /* every required parameter */ }
   }
 }
-
-If no function fits, respond with:
-{ "function": null }
 """
 
 
 logger = logging.getLogger(__name__)
+
+
+@tool
+def play_music(url: str | None = None, query: str | None = None) -> tuple[bool, str]:
+    """Play a song, playlist or stream in the default browser."""
+    if not url and query:
+        q = urllib.parse.quote_plus(query)
+        url = f"https://www.youtube.com/results?search_query={q}"
+    if url:
+        try:
+            webbrowser.open(url)
+            return True, f"Playing {query or url}"
+        except Exception as exc:  # pragma: no cover - platform dependent
+            return False, str(exc)
+    return False, "No URL provided"
+
+_TOOL_SCHEMA_MAP["play_music"] = {
+    "type": "object",
+    "properties": {
+        "url": {
+            "type": "string",
+            "description": "A direct media URL (YouTube, Spotify, SoundCloud, etc.)",
+        },
+        "query": {
+            "type": "string",
+            "description": "A free-text search term if the user did not supply a URL",
+        },
+    },
+    "required": ["url"],
+}
 
 
 def _safe_json_load(raw: str) -> Dict[str, Any] | None:
@@ -57,24 +91,34 @@ def _safe_json_load(raw: str) -> Dict[str, Any] | None:
     return None
 
 
-def summarise_router_reply(reply: str | Dict[str, Any]) -> Optional[str]:
-    """
-    Returns the chosen function's name (str) or None.
-    Works with both the new nested schema and the legacy flat schema.
-    Never raises JSONDecodeError or AttributeError.
-    """
+def summarise_router_reply(reply: str | Dict[str, Any]) -> tuple[str | None, Dict[str, Any]]:
+    """Return (function_name, arguments) from *reply* without raising."""
     if isinstance(reply, dict):
         obj = reply
     else:
         obj = _safe_json_load(reply) or {}
 
+    name: str | None = None
+    args: Dict[str, Any] = {}
+
     func = obj.get("function")
 
     if isinstance(func, dict):
-        return func.get("name")
+        name = func.get("name")
+        raw_args = func.get("arguments", {})
+        if isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args)
+            except json.JSONDecodeError:
+                args = {}
+        elif isinstance(raw_args, dict):
+            args = raw_args
     elif isinstance(func, str):
-        return func
-    return None
+        name = func
+        raw_args = obj.get("arguments", {})
+        if isinstance(raw_args, dict):
+            args = raw_args
+    return name, args
 
 
 async def microphone_chunks() -> AsyncGenerator[bytes, None]:

--- a/tests/test_router_summary.py
+++ b/tests/test_router_summary.py
@@ -9,20 +9,28 @@ from app.assistant import summarise_router_reply  # noqa: E402
 
 def test_dict_input_old_schema():
     obj = {"function": "launch_app"}
-    assert summarise_router_reply(obj) == "launch_app"
+    name, args = summarise_router_reply(obj)
+    assert name == "launch_app"
+    assert args == {}
 
 
 def test_open_website_string_new_schema():
     data = (
         '{"function": {"name": "open_website", "arguments": {"url": "google.com"}}}'
     )
-    assert summarise_router_reply(data) == "open_website"
+    name, args = summarise_router_reply(data)
+    assert name == "open_website"
+    assert args["url"] == "google.com"
 
 
 def test_invalid_json():
-    assert summarise_router_reply('') is None
+    name, args = summarise_router_reply('')
+    assert name is None
+    assert args == {}
 
 
 def test_noise_wrapped_json():
     text = 'LOG something {"function": {"name": "search_files"}} end'
-    assert summarise_router_reply(text) == "search_files"
+    name, args = summarise_router_reply(text)
+    assert name == "search_files"
+    assert args == {}


### PR DESCRIPTION
## Summary
- add a dedicated `play_music` tool with URL/query logic
- send updated tool list and prompt in `IntentRouter`
- improve router with regex fallback for URLs and play commands
- extend `summarise_router_reply` to return function name and args
- adjust tests for new return format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bb46f5888320905bb92395bc96ae