### PR TITLE
Upgrade to Edge-TTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install edge-tts==1.6.2
+          pip install -r requirements.txt
+      - name: Lint and Test
+        run: |
+          ruff check .
+          pytest -q

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "wake_word": "Hey Aurora",
   "debug": true,
-  "tts_engine": "gtts"
-  ,"conversational_mode": true
+  "tts_engine": "gtts",
+  "tts": { "engine": "edge", "voice": "en-US-AriaNeural" },
+  "conversational_mode": true
 }

--- a/core/config.py
+++ b/core/config.py
@@ -9,7 +9,7 @@ MODEL_NAME = "mistral:7b-instruct"
 _DEFAULT = {
     "wake_word": "Hey Aurora",
     "debug": True,
-    "tts_engine": "gtts",
+    "tts_engine": "edge",
     "conversational_mode": True,
 }
 

--- a/kyra_full_installer_and_fixes.txt
+++ b/kyra_full_installer_and_fixes.txt
@@ -13,6 +13,6 @@ Batch files provided:
 Python fixes include:
 - Graceful handling of microphone errors when starting audio capture.
 - Unified logging of user input and assistant response for both text and voice modes.
-- Lower log verbosity for Vosk, urllib3 and gTTS unless debug is enabled.
+- Lower log verbosity for Vosk, urllib3 and Microsoft Edge-TTS neural voices unless debug is enabled.
 - Simplified play_music fallback to open a YouTube search when no direct URL is given.
 - Text-to-speech now reports failures and cleans up temporary files.

--- a/playsound.py
+++ b/playsound.py
@@ -1,2 +1,0 @@
-def playsound(path):
-    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 vosk
 requests
 pydantic
-edge-tts
+edge-tts==1.6.2
 pyttsx3
 rapidfuzz>=3
 rich

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,6 @@ install_requires =
     vosk
     requests
     pydantic
-    gTTS
-    playsound==1.2.2
     rapidfuzz
     jsonschema
 python_requires = >=3.10

--- a/tests/test_speak_edge.py
+++ b/tests/test_speak_edge.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import types
+
+# Provide stub pyaudio so importing speak doesn't require system deps
+sys.modules['pyaudio'] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.assistant import speak  # noqa: E402
+
+
+def test_speak_no_tts():
+    speak("test", False)


### PR DESCRIPTION
## Summary
- switch from gTTS to Microsoft Edge-TTS
- pin `edge-tts==1.6.2` and drop gTTS/playsound from packaging
- support new `tts` config block and update defaults
- implement new Edge-TTS based `speak()`
- add CI workflow and new tests
- clean documentation

## Testing
- `ruff check --fix app/assistant.py core/config.py tests/test_speak_edge.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491931139c832085761b7a390ee6ff