### PR TITLE
Implement Edge TTS and improve intent handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,3 @@
+VOICE_NAME = "en-US-JennyNeural"
+VOICE_RATE = "+5%"
+AUDIO_CACHE = ".voice_cache"

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -120,7 +120,10 @@ class IntentRouter:
                 return None, {}, "unknown"
             call = calls[0]
             name = call.get("function", {}).get("name")
-            args_json = call.get("function", {}).get("arguments", "{}")
+            args_json = call.get("function", {}).get("arguments", "")
+            if not name or not args_json:
+                content = msg.get("content", "")
+                return None, {"content": content}, "chat"
             try:
                 args = json.loads(args_json)
             except json.JSONDecodeError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ vosk
 requests
 pydantic
 edge-tts
-pyttsx3
+simpleaudio
 rapidfuzz>=3
 rich
 jsonschema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,12 @@ sys.modules.setdefault('vosk', types.SimpleNamespace(Model=lambda *a, **k: None,
 sys.modules.setdefault('pyaudio', types.SimpleNamespace(PyAudio=lambda: None, paInt16=0))
 sys.modules.setdefault('rapidfuzz', types.SimpleNamespace(fuzz=types.SimpleNamespace(partial_ratio=lambda a, b: 0)))
 sys.modules.setdefault('pydantic', types.SimpleNamespace(BaseModel=object))
-sys.modules.setdefault('edge_tts', types.SimpleNamespace(Communicate=lambda *a, **k: types.SimpleNamespace(save=lambda p: None)))
+async def _dummy_save(path: str) -> None:
+    return None
+
+sys.modules.setdefault('edge_tts', types.SimpleNamespace(Communicate=lambda *a, **k: types.SimpleNamespace(save=_dummy_save)))
 sys.modules.setdefault('pyttsx3', types.SimpleNamespace(init=lambda: types.SimpleNamespace(say=lambda t: None, runAndWait=lambda: None)))
+sys.modules.setdefault('simpleaudio', types.SimpleNamespace(WaveObject=types.SimpleNamespace(from_wave_file=lambda p: types.SimpleNamespace(play=lambda: types.SimpleNamespace(wait_done=lambda: None)))))
 sys.modules.setdefault('rich.console', types.SimpleNamespace(Console=lambda *a, **k: types.SimpleNamespace(print=lambda *a, **k: None)))
 sys.modules.setdefault('rich.text', types.SimpleNamespace(Text=lambda *a, **k: None))
 

--- a/tests/test_play_music.py
+++ b/tests/test_play_music.py
@@ -1,7 +1,5 @@
 import os, sys, types
 
-sys.modules['pyaudio'] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.assistant import play_music
 

--- a/tests/test_router_summary.py
+++ b/tests/test_router_summary.py
@@ -1,9 +1,6 @@
 import sys
 import types
 
-# Stub pyaudio so importing assistant works without system deps
-sys.modules["pyaudio"] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
-
 from app.assistant import summarise_router_reply  # noqa: E402
 
 

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -1,13 +1,10 @@
-import os, sys, types
-
-# Provide stub pyaudio so importing speak doesn't require system deps
-sys.modules['pyaudio'] = types.SimpleNamespace(PyAudio=lambda: None, paInt16=0)
+import os, sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from app.assistant import speak
 
 
 def test_speak_empty(monkeypatch):
-    monkeypatch.setattr("app.tts.safe_speak", lambda text: None)
+    monkeypatch.setattr("app.tts.speak", lambda text: None)
     speak("", True)
     speak("   ", True)

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,19 +1,9 @@
-import os, sys, types
-import pytest
-
-# Stub pyttsx3 and edge_tts so safe_speak imports without deps
-sys.modules.setdefault('pyttsx3', types.SimpleNamespace(init=lambda: types.SimpleNamespace(say=lambda t: None, runAndWait=lambda: None)))
-edge_mock = types.SimpleNamespace(Communicate=lambda text, voice: types.SimpleNamespace(save=lambda f: None))
-sys.modules.setdefault('edge_tts', edge_mock)
+import asyncio
+import os, sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from app.tts import safe_speak
+from app.tts import speak
 
-def test_safe_speak_empty():
-    import asyncio
-    with pytest.raises(ValueError):
-        asyncio.run(safe_speak(""))
 
-def test_safe_speak_runs():
-    import asyncio
-    asyncio.run(safe_speak("hi"))
+def test_speak_runs():
+    asyncio.run(speak("This is only a test."))


### PR DESCRIPTION
## Summary
- add Edge TTS configuration
- redesign TTS layer using cached wav files and simpleaudio
- harden intent routing and argument cleanup
- add silence debounce for wake‑word listener
- update startup log message
- update tests for new TTS behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491f107fd48320b858ded83ea8bfb4