### PR TITLE
Implement note and path tools

### DIFF
--- a/app/assistant.py
+++ b/app/assistant.py
@@ -168,12 +168,15 @@ def _fix_wake_word(text: str) -> str:
 
 
 _STOP_WORDS = re.compile(
-    r"^(?:the|a|an|process|explorer(?: to)?|explore(?: to)?)\s+", re.I
+    r"^(?:the|a|an|process|folder|directory|explorer(?: to)?|explore(?: to)?)\s+",
+    re.I,
 )
 
 
 def _clean_arg(arg: str) -> str:
-    return _STOP_WORDS.sub("", arg.strip())
+    text = _STOP_WORDS.sub("", arg.strip())
+    text = re.sub(r"\bdesks? top\b", "desktop", text, flags=re.I)
+    return text
 
 
 _SMALL_TALK = [

--- a/app/assistant.py
+++ b/app/assistant.py
@@ -167,7 +167,9 @@ def _fix_wake_word(text: str) -> str:
     return re.sub(pattern, WAKE_WORD, text, flags=re.I)
 
 
-_STOP_WORDS = re.compile(r"^(?:the|a|an|process)\s+", re.I)
+_STOP_WORDS = re.compile(
+    r"^(?:the|a|an|process|explorer(?: to)?|explore(?: to)?)\s+", re.I
+)
 
 
 def _clean_arg(arg: str) -> str:
@@ -274,6 +276,8 @@ def handle_text(text: str, router: IntentRouter, tts: bool, transcript: Transcri
                 act.args["name"] = _clean_arg(act.args.get("name", ""))
             if act.name == "open_website":
                 act.args["url"] = _clean_arg(act.args.get("url", ""))
+            if act.name == "open_explorer":
+                act.args["path"] = _clean_arg(act.args.get("path", ""))
             if DEBUG:
                 transcript.log("FUNC", f"{act.name} {act.args} | raw='{text}'")
             ok, msg = _REGISTRY[act.name]["callable"](**act.args)
@@ -291,6 +295,8 @@ def handle_text(text: str, router: IntentRouter, tts: bool, transcript: Transcri
             args_route["url"] = _clean_arg(args_route.get("url", ""))
             if not args_route["url"]:
                 name = None
+        if name == "open_explorer":
+            args_route["path"] = _clean_arg(args_route.get("path", ""))
         if name and DEBUG:
             transcript.log("FUNC", f"{name} {args_route} | raw='{text}'")
         if name:

--- a/app/assistant.py
+++ b/app/assistant.py
@@ -153,6 +153,10 @@ def summarise_router_reply(reply: str | Dict[str, Any]) -> str:
         return f"Downloading {args['package']}"
     if name == "kill_process" and "name" in args:
         return f"Killing {args['name']}"
+    if name == "open_explorer" and "path" in args:
+        return f"Opening {args['path']}"
+    if name == "create_note" and "content" in args:
+        return "Saved note"
     return name
 
 

--- a/app/intent_router.py
+++ b/app/intent_router.py
@@ -15,7 +15,10 @@ class Action:
 
 _PATTERNS = {
     "open_explorer": (
-        re.compile(r"(?:open|show) (?P<path>(?:[A-Za-z]:|~|/).+|.+(?:folder|directory).*)", re.I),
+        re.compile(
+            r"(?:open|show)(?: .{0,20}?explor(?:er|e)(?: to)?)? (?P<path>(?:[A-Za-z]:|~|/).+|.+(?:folder|directory).*|(?:desktop|downloads|documents|pictures|music|videos)(?:\b|$))",
+            re.I,
+        ),
         "path",
     ),
     "create_note": (re.compile(r"(?:note|remember) (?P<content>.+)", re.I), "content"),

--- a/app/intent_router.py
+++ b/app/intent_router.py
@@ -14,6 +14,11 @@ class Action:
 
 
 _PATTERNS = {
+    "open_explorer": (
+        re.compile(r"(?:open|show) (?P<path>(?:[A-Za-z]:|~|/).+|.+(?:folder|directory).*)", re.I),
+        "path",
+    ),
+    "create_note": (re.compile(r"(?:note|remember) (?P<content>.+)", re.I), "content"),
     "open_website": (re.compile(r"(?:open|visit|go to) (?P<url>.+)", re.I), "url"),
     "launch_app": (re.compile(r"(?:launch|open|start) (?P<exe>.+)", re.I), "app"),
     "play_song": (re.compile(r"(?:play|listen to) (?P<song>.+)", re.I), "query"),
@@ -22,6 +27,8 @@ _PATTERNS = {
 }
 
 _CHOICES = {
+    "open_explorer": "open folder",
+    "create_note": "create note",
     "open_website": "open website",
     "launch_app": "launch app",
     "play_song": "play song",

--- a/core/tools.py
+++ b/core/tools.py
@@ -132,6 +132,15 @@ import webbrowser
 import pathlib
 import time
 
+COMMON_DIRS = {
+    "desktop": str(pathlib.Path.home() / "Desktop"),
+    "downloads": str(pathlib.Path.home() / "Downloads"),
+    "documents": str(pathlib.Path.home() / "Documents"),
+    "pictures": str(pathlib.Path.home() / "Pictures"),
+    "music": str(pathlib.Path.home() / "Music"),
+    "videos": str(pathlib.Path.home() / "Videos"),
+}
+
 
 def sanitize_domain(text: str) -> str:
     """Return a clean domain or empty string if *text* is not valid."""
@@ -227,7 +236,9 @@ def kill_process(name: str) -> Tuple[bool, str]:
 @tool
 def open_explorer(path: str) -> Tuple[bool, str]:
     """Open a file or directory in the system file explorer."""
-    target = os.path.expanduser(path)
+    key = path.strip().lower()
+    target = COMMON_DIRS.get(key, path)
+    target = os.path.expanduser(target)
     if not os.path.exists(target):
         return False, f"{target} not found"
     try:

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -12,3 +12,10 @@ def test_fuzzy_open():
     assert isinstance(act, Action)
     assert act.name == "open_website"
     assert "url" in act.args
+
+
+def test_fuzzy_open_folder():
+    act = fuzzy_match("open ~/Downloads")
+    assert isinstance(act, Action)
+    assert act.name == "open_explorer"
+    assert "path" in act.args

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -19,3 +19,10 @@ def test_fuzzy_open_folder():
     assert isinstance(act, Action)
     assert act.name == "open_explorer"
     assert "path" in act.args
+
+
+def test_fuzzy_open_explorer_phrase():
+    act = fuzzy_match("open explorer to desktop")
+    assert isinstance(act, Action)
+    assert act.name == "open_explorer"
+    assert act.args["path"].lower() == "desktop"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,10 +25,20 @@ def test_open_explorer(monkeypatch, tmp_path):
     assert opened
 
 
+def test_open_explorer_common_dir(monkeypatch, tmp_path):
+    opened = []
+    monkeypatch.setattr(tools.webbrowser, "open", lambda url: opened.append(url) or True)
+    monkeypatch.setitem(tools.COMMON_DIRS, "desktop", str(tmp_path))
+    ok, msg = tools.open_explorer("desktop")
+    assert ok
+    assert opened
+
+
 def test_clean_arg_explorer():
     from app.assistant import _clean_arg
 
     assert _clean_arg("explorer to desktop") == "desktop"
+    assert _clean_arg("folder desk top") == "desktop"
 
 
 def test_create_note(tmp_path):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,6 +25,12 @@ def test_open_explorer(monkeypatch, tmp_path):
     assert opened
 
 
+def test_clean_arg_explorer():
+    from app.assistant import _clean_arg
+
+    assert _clean_arg("explorer to desktop") == "desktop"
+
+
 def test_create_note(tmp_path):
     ok, msg = tools.create_note("buy milk", directory=str(tmp_path))
     assert ok

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,3 +15,19 @@ def test_derive_glob_from_phrase():
     assert pattern == "*.pdf"
     pattern2 = tools.derive_glob_from_phrase("my notes")
     assert pattern2 == "*my*notes*"
+
+
+def test_open_explorer(monkeypatch, tmp_path):
+    opened = []
+    monkeypatch.setattr(tools.webbrowser, "open", lambda url: opened.append(url) or True)
+    ok, msg = tools.open_explorer(str(tmp_path))
+    assert ok
+    assert opened
+
+
+def test_create_note(tmp_path):
+    ok, msg = tools.create_note("buy milk", directory=str(tmp_path))
+    assert ok
+    files = list(tmp_path.glob("note_*.txt"))
+    assert files
+    assert files[0].read_text().strip() == "buy milk"


### PR DESCRIPTION
## Summary
- expose new `open_explorer`, `find_file_and_open` and `create_note` tools
- extend intent router patterns and choices to detect these commands
- add short confirmations in assistant summary logic
- add unit tests for the new tools and fuzzy matching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492408ed1c832086c9e8837e07aad0